### PR TITLE
refactor: add support for different alert types and dynamic icons

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -5,6 +5,7 @@ const Configuration: UserConfig = {
     parserPreset: 'conventional-changelog-atom',
     formatter: '@commitlint/format',
     rules: {
+        'body-max-line-length': [2, 'always', 200],
         'type-enum': [
             2,
             'always',

--- a/src/_components/ui/alert-error.tsx
+++ b/src/_components/ui/alert-error.tsx
@@ -2,7 +2,7 @@
 // @ts-nocheck
 
 import { AlertContext } from "@/_context/alertContext";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, CheckCircle, Info, TriangleAlert } from "lucide-react";
 import { ReactNode, useState } from "react";
 import {
   AlertDialog,
@@ -14,6 +14,31 @@ import {
   AlertDialogTitle,
 } from "./alert-dialog";
 
+type AlertType = "error" | "success" | "warning" | "info";
+
+const iconMap: Record<AlertType, ReactNode> = {
+  error: (
+    <div className="flex items-center justify-center rounded-full bg-destructive/10 p-4">
+      <AlertCircle className="text-destructive size-7" />
+    </div>
+  ),
+  success: (
+    <div className="flex items-center justify-center rounded-full bg-green-500/10 p-4">
+      <CheckCircle className="text-green-500 size-7" />
+    </div>
+  ),
+  warning: (
+    <div className="flex items-center justify-center rounded-full bg-yellow-500/10 p-4">
+      <TriangleAlert className="text-yellow-500 size-7" />
+    </div>
+  ),
+  info: (
+    <div className="flex items-center justify-center rounded-full bg-blue-500/10 p-4">
+      <Info className="text-blue-500 size-7" />
+    </div>
+  ),
+};
+
 interface AlertErrorProps {
   children: ReactNode;
 }
@@ -22,10 +47,16 @@ export function AlertError({ children }: AlertErrorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [error, setError] = useState("");
   const [title, setTitle] = useState("Something went wrong!");
+  const [alertType, setAlertType] = useState<AlertType>("error");
 
-  const openError = (errorMessage: string, newTitle?: string) => {
+  const openError = (
+    errorMessage: string,
+    newTitle?: string,
+    type?: AlertType
+  ) => {
     setTitle(newTitle || "Something went wrong!");
     setError(errorMessage);
+    setAlertType(type || "error");
     setIsOpen(true);
   };
 
@@ -38,9 +69,8 @@ export function AlertError({ children }: AlertErrorProps) {
         <AlertDialogContent className="flex items-end md:items-center bg-transparent w-full md:w-fit h-full shadow-none m-0 p-0 border-0">
           <div className="bg-background overflow-y-auto w-full md:w-fit h-fit mb-2 md:mb-0 mx-2 md:mx-0">
             <div className="flex px-3 md:px-6 py-3 md:py-6 gap-2 md:gap-4 items-center">
-              <div className="flex items-center justify-center rounded-full bg-destructive/10 p-4">
-                <AlertCircle className="text-destructive size-7" />
-              </div>
+              {iconMap[alertType]}
+
               <AlertDialogHeader className="dark:text-secondary">
                 <AlertDialogTitle className="flex w-full text-base md:text-lg font-bold">
                   {title}

--- a/src/_context/alertContext.ts
+++ b/src/_context/alertContext.ts
@@ -1,7 +1,9 @@
 import { createContext } from "react";
 
+type AlertType = "error" | "success" | "warning" | "info";
+
 interface AlertContextProps {
-  openError: (message: string, title?: string) => void;
+  openError: (message: string, title?: string, type?: AlertType) => void;
 }
 
 export const AlertContext = createContext<AlertContextProps | undefined>(

--- a/src/app/(public)/singup/page.tsx
+++ b/src/app/(public)/singup/page.tsx
@@ -48,6 +48,11 @@ export default function SingUp() {
     }
 
     if (data) {
+      openError(
+        "Activation instructions have been sent to your email.",
+        "Registration Successful!",
+        "success"
+      );
       router.push("/singIn");
     }
   }


### PR DESCRIPTION
- Added `type` property to `AlertContext` to support multiple alert types (`error`, `success`, `warning`, `info`).
- Defined an icon map to display different icons based on the alert type.
- Updated `openError` function to accept and handle the new `type` parameter.